### PR TITLE
added configuration variables

### DIFF
--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -106,6 +106,9 @@ void MAX31865Sensor::dump_config() {
   LOG_SENSOR("", "MAX31865", this);
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_UPDATE_INTERVAL(this);
+  ESP_LOGCONFIG(TAG, "  even count of wires: %s", this->even_pins_ ? "True" : "False");
+  ESP_LOGCONFIG(TAG, "  sensor nominal resistance: %.1f", this->r_nominal_);
+  ESP_LOGCONFIG(TAG, "  reference restistance %.1f", this->r_ref_);
 }
 
 float MAX31865Sensor::get_setup_priority() const { return setup_priority::DATA; }
@@ -155,13 +158,7 @@ void MAX31865Sensor::read_data_() {
     return;
   }
 
-// TODO: Support parameterization
-// The value of the Rref resistor. Use 430.0 for PT100 and 4300.0 for PT1000
-#define RREF 4300.0
-// The 'nominal' 0-degrees-C resistance of the sensor 100.0 for PT100, 1000.0 for PT1000
-#define RNOMINAL 1000.0
-
-  float temperature = this->temperature(val, RNOMINAL, RREF);
+  float temperature = this->temperature(val, this->r_nominal_, this->r_ref_);
   ESP_LOGD(TAG, "'%s': Got temperature=%.1f°C", this->name_.c_str(), temperature);
   this->publish_state(temperature);
   this->status_clear_warning();

--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -17,6 +17,7 @@
 #define MAX31865_CFG_MODE (0x40)  // 1 - Auto conversion
 #define MAX31865_CFG_BIAS (0x80)  // 1 - Vbias Enabled
 #define MAX31865_CFG_WIRE_EVEN(x) x ? 0 : MAX31865_CFG_WIRE
+#define MAX31865_CFG_FILTER_50HZ(x) x ? 0 : MAX31865_CFG_6050
 
 #define MAX31865_RTD_L_FLT (0x01)  // Indicates Fault
 
@@ -83,7 +84,7 @@ void MAX31865Sensor::write_config_() {
   delay(1);
   this->write_byte(MAX31865_CFG | MAX31865_WRITE);
   this->write_byte(MAX31865_CFG_FLTC | MAX31865_CFG_WIRE_EVEN(this->even_pins_) | MAX31865_CFG_MODE |
-                   MAX31865_CFG_BIAS);  // TODO: Allow user to specify configuration
+                   MAX31865_CFG_FILTER_50HZ(this->filter_50hz_) | MAX31865_CFG_BIAS);
   this->disable();
 }
 

--- a/esphome/components/max31865/max31865.h
+++ b/esphome/components/max31865/max31865.h
@@ -16,6 +16,8 @@ class MAX31865Sensor : public sensor::Sensor,
   void dump_config() override;
   float get_setup_priority() const override;
   void set_pin_count(bool even = false) { this->even_pins_ = even; }
+  void set_r_nominal(float r = 1000) { this->r_nominal_ = r; };
+  void set_r_ref(float r = 4300) { this->r_ref_ = r; };
 
   void update() override;
 
@@ -25,6 +27,8 @@ class MAX31865Sensor : public sensor::Sensor,
   void read_data_();
   void write_config_();
   bool even_pins_;
+  float r_nominal_;
+  float r_ref_;
 };
 
 }  // namespace max31865

--- a/esphome/components/max31865/max31865.h
+++ b/esphome/components/max31865/max31865.h
@@ -18,6 +18,7 @@ class MAX31865Sensor : public sensor::Sensor,
   void set_pin_count(bool even = false) { this->even_pins_ = even; }
   void set_r_nominal(float r = 1000) { this->r_nominal_ = r; };
   void set_r_ref(float r = 4300) { this->r_ref_ = r; };
+  void set_filter_50hz(bool b = false) { this->filter_50hz_ = b; };
 
   void update() override;
 
@@ -29,6 +30,7 @@ class MAX31865Sensor : public sensor::Sensor,
   bool even_pins_;
   float r_nominal_;
   float r_ref_;
+  bool filter_50hz_;
 };
 
 }  // namespace max31865

--- a/esphome/components/max31865/sensor.py
+++ b/esphome/components/max31865/sensor.py
@@ -6,6 +6,8 @@ from esphome.const import CONF_ID, ICON_THERMOMETER, UNIT_CELSIUS
 DEPENDENCIES = ['spi']
 
 CONF_PIN_COUNT = 'even_pin_count'
+CONF_R_NOMINAL = 'r_nominal'
+CONF_R_REF = 'r_ref'
 
 max31865_ns = cg.esphome_ns.namespace('max31865')
 MAX31865Sensor = max31865_ns.class_('MAX31865Sensor', sensor.Sensor, cg.PollingComponent,
@@ -15,6 +17,8 @@ CONFIG_SCHEMA = sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1).extend({
     cv.GenerateID(): cv.declare_id(MAX31865Sensor),
 }).extend(cv.polling_component_schema('60s')).extend(spi.SPI_DEVICE_SCHEMA).extend({
     cv.Optional(CONF_PIN_COUNT, default=False): cv.boolean,
+    cv.Optional(CONF_R_NOMINAL, default=1000.0): cv.float_,
+    cv.Optional(CONF_R_REF, default=4300.0): cv.float_,
 })
 
 
@@ -22,5 +26,7 @@ def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     yield cg.register_component(var, config)
     cg.add(var.set_pin_count(config[CONF_PIN_COUNT]))
+    cg.add(var.set_r_nominal(config[CONF_R_NOMINAL]))
+    cg.add(var.set_r_ref(config[CONF_R_REF]))
     yield spi.register_spi_device(var, config)
     yield sensor.register_sensor(var, config)

--- a/esphome/components/max31865/sensor.py
+++ b/esphome/components/max31865/sensor.py
@@ -8,6 +8,7 @@ DEPENDENCIES = ['spi']
 CONF_PIN_COUNT = 'even_pin_count'
 CONF_R_NOMINAL = 'r_nominal'
 CONF_R_REF = 'r_ref'
+CONF_FILTER_50HZ = 'filter_50hz'
 
 max31865_ns = cg.esphome_ns.namespace('max31865')
 MAX31865Sensor = max31865_ns.class_('MAX31865Sensor', sensor.Sensor, cg.PollingComponent,
@@ -19,6 +20,7 @@ CONFIG_SCHEMA = sensor.sensor_schema(UNIT_CELSIUS, ICON_THERMOMETER, 1).extend({
     cv.Optional(CONF_PIN_COUNT, default=False): cv.boolean,
     cv.Optional(CONF_R_NOMINAL, default=1000.0): cv.float_,
     cv.Optional(CONF_R_REF, default=4300.0): cv.float_,
+    cv.Optional(CONF_FILTER_50HZ, default=False): cv.boolean,
 })
 
 
@@ -28,5 +30,6 @@ def to_code(config):
     cg.add(var.set_pin_count(config[CONF_PIN_COUNT]))
     cg.add(var.set_r_nominal(config[CONF_R_NOMINAL]))
     cg.add(var.set_r_ref(config[CONF_R_REF]))
+    cg.add(var.set_filter_50hz(config[CONF_FILTER_50HZ]))
     yield spi.register_spi_device(var, config)
     yield sensor.register_sensor(var, config)


### PR DESCRIPTION
## Description:
This PR adds configuration variables:
* r_nominal: nominal resistance of thermo element (default is 1000 ohm)
* r_reference: reference resistance (default is 4300 ohm)
* filter_50hz: if set, the chip is set to activate its 50 hz filter

**esphome/esphome#732:** 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
